### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/docs-deployment.yaml
+++ b/.github/workflows/docs-deployment.yaml
@@ -20,7 +20,7 @@ jobs:
         id: get_version
         run: echo ::set-output name=VERSION::$(cat version.txt)
       - name: Build and publish docker image
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: docs-storefrontcloud-io/v2-cope:${{ steps.get_version.outputs.VERSION }}
           registry: registry.storefrontcloud.io


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore